### PR TITLE
fix(season-answers): Make season ID dynamic instead of hardcoded

### DIFF
--- a/src/app/api/season-answers/route.ts
+++ b/src/app/api/season-answers/route.ts
@@ -64,8 +64,19 @@ export async function POST(request: NextRequest) {
     }
 
     // 3. Prepare data for Supabase Upsert
-    // TODO: Determine the correct season_id dynamically later. Hardcoding for now.
-    const seasonId = 1; // Assuming season ID 1 for Premier League 2024/2025 based on previous context
+    // Get the current season dynamically instead of hardcoding
+    const { data: currentSeason, error: seasonError } = await supabase
+        .from('seasons')
+        .select('id')
+        .eq('is_current', true)
+        .single();
+
+    if (seasonError || !currentSeason) {
+        console.error('POST /api/season-answers: Failed to fetch current season:', seasonError);
+        return NextResponse.json({ error: 'Failed to determine current season' }, { status: 500 });
+    }
+
+    const seasonId = currentSeason.id; // Use the current season ID dynamically
 
     const answersToUpsert = answersData.map(answer => ({
         user_id: user.id,


### PR DESCRIPTION
🐛 Critical Fix for Dynamic Points System:
- Season answers API now fetches current season dynamically instead of hardcoding season ID 1
- This resolves the issue where predictions were saved to wrong season (ID 1 vs current ID 7)
- Dynamic points system can now find user predictions for the correct current season

🔧 Test Improvements:
- Enhanced mock Supabase client to support new season query chaining (.select().eq().single())
- Added proper season mocks to all test cases that reach the season query logic
- Updated test expectations to verify dynamic season ID usage
- All 9 season-answers tests now passing

Impact: This fixes the critical bug where dynamic points processing found 0 user answers because predictions were stored with wrong season ID. Now predictions will be stored and retrieved using the correct current season ID.

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 