### PR TITLE
fix: ensure matches display in chronological order in betting coupon

### DIFF
--- a/src/lib/supabase/queries.test.ts
+++ b/src/lib/supabase/queries.test.ts
@@ -222,8 +222,10 @@ describe('Supabase Queries', () => {
         if (tableName === 'fixtures') {
           return {
             select: jest.fn(() => ({ 
-              // .in(...) is the terminal call for this path in the actual code
-              in: fromFixturesMock 
+              // .in(...).order(...) is the terminal chain for this path in the actual code
+              in: jest.fn(() => ({
+                order: fromFixturesMock
+              }))
             }))
           };
         }

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -303,7 +303,8 @@ export async function getCurrentBettingRoundFixtures(): Promise<CurrentRoundFixt
         home_team:teams!fixtures_home_team_id_fkey(id, name),
         away_team:teams!fixtures_away_team_id_fkey(id, name)
       `)
-      .in('id', roundFixturesData.map(f => f.fixture_id));
+      .in('id', roundFixturesData.map(f => f.fixture_id))
+      .order('kickoff', { ascending: true });
 
     if (fixtureDetailsError) {
       console.error(`Error fetching fixture details for betting round ${openRoundId}:`, fixtureDetailsError);


### PR DESCRIPTION
- Add missing .order('kickoff', { ascending: true }) to getCurrentBettingRoundFixtures query
- Update test mock to handle new query chain with .order() method
- Fixes issue where first match was displayed out of chronological sequence
- Ensures consistent chronological sorting for better betting UX

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 