### PR TITLE
feat(transparency): Implement answers page with user predictions & cu…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.7",
         "@radix-ui/react-popover": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.0",
+        "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.6",
         "@react-email/body": "^0.0.11",
         "@react-email/button": "^0.1.0",
@@ -2800,6 +2801,73 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -2862,6 +2930,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3091,10 +3174,153 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
+      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
       "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
+      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dialog": "^1.1.7",
     "@radix-ui/react-popover": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.0",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.6",
     "@react-email/body": "^0.0.11",
     "@react-email/button": "^0.1.0",

--- a/src/app/answers/page.tsx
+++ b/src/app/answers/page.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import UserPredictionsTable from '@/components/answers/UserPredictionsTable';
+import CurrentAnswersTable from '@/components/answers/CurrentAnswersTable';
+import { logger } from '@/utils/logger';
+
+// Types for the data we'll fetch
+interface UserPrediction {
+  user_id: string;
+  username?: string;
+  league_winner?: string;
+  best_goal_difference?: string;
+  top_scorer?: string;
+  last_place?: string;
+}
+
+interface CurrentAnswer {
+  question_type: string;
+  question_label: string;
+  current_answer: string;
+  points_value: number;
+}
+
+interface TransparencyData {
+  userPredictions: UserPrediction[];
+  currentAnswers: CurrentAnswer[];
+  season_id: number;
+}
+
+async function getTransparencyData(): Promise<TransparencyData | null> {
+  const loggerContext = { page: '/answers', function: 'getTransparencyData' };
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/api/season-answers`, {
+      method: 'GET',
+      cache: 'no-store', // Ensure we get fresh data
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data: TransparencyData = await response.json();
+    
+    logger.info({ 
+      ...loggerContext, 
+      userPredictions: data.userPredictions.length, 
+      currentAnswers: data.currentAnswers.length,
+      seasonId: data.season_id 
+    }, 'Successfully fetched transparency data from API.');
+    
+    return data;
+  } catch (error) {
+    logger.error(
+      { ...loggerContext, error: error instanceof Error ? error.message : String(error) },
+      'Failed to fetch transparency data from API'
+    );
+    return null;
+  }
+}
+
+/**
+ * Answers Page - Shows transparency data for season predictions
+ * 
+ * Displays two tabs:
+ * 1. User Predictions - All user season predictions
+ * 2. Current Leaders - Current correct answers (with multiple answers support)
+ */
+export default async function AnswersPage() {
+  const transparencyData = await getTransparencyData();
+
+  if (!transparencyData) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-4">Season Answers</h1>
+        <p className="text-red-500">Failed to load answers data. Please try again later.</p>
+      </div>
+    );
+  }
+
+  const { userPredictions, currentAnswers } = transparencyData;
+  const hasUserPredictions = userPredictions && userPredictions.length > 0;
+  const hasCurrentAnswers = currentAnswers && currentAnswers.length > 0;
+
+  if (!hasUserPredictions && !hasCurrentAnswers) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-4">Season Answers</h1>
+        <p className="text-gray-600">No transparency data available at this time.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Season Answers</h1>
+      <p className="text-gray-600 mb-6">
+        View everyone&apos;s season predictions and current correct answers for transparency.
+      </p>
+      
+      <Tabs defaultValue="predictions" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 mb-6">
+          <TabsTrigger value="predictions">User Answers</TabsTrigger>
+          <TabsTrigger value="current">Correct Answers</TabsTrigger>
+        </TabsList>
+        
+        <TabsContent value="predictions">
+          <UserPredictionsTable data={userPredictions} />
+        </TabsContent>
+        
+        <TabsContent value="current">
+          <CurrentAnswersTable data={currentAnswers} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+} 

--- a/src/app/api/season-answers/route.ts
+++ b/src/app/api/season-answers/route.ts
@@ -2,6 +2,46 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import LeagueDataService from '@/lib/leagueDataService';
+import { getSupabaseServiceRoleClient } from '@/utils/supabase/service';
+
+// Types for transparency data
+interface UserPrediction {
+  user_id: string;
+  username?: string;
+  league_winner?: string | null;
+  best_goal_difference?: string | null;
+  top_scorer?: string | null;
+  last_place?: string | null;
+}
+
+interface _CurrentAnswer {
+  question_type: string;
+  question_label: string;
+  current_answer: string;
+  points_value: number;
+}
+
+// Type for raw user answer data from Supabase
+interface RawUserAnswer {
+    user_id: string;
+    question_type: string;
+    answered_team_id: number | null;
+    answered_player_id: number | null;
+}
+
+interface TeamData {
+    id: number;
+    name: string | null;
+}
+
+interface PlayerData {
+    id: number;
+    name: string | null;
+}
+
+// Type for Supabase service role client
+type ServiceRoleClient = ReturnType<typeof getSupabaseServiceRoleClient>;
 
 // Zod schema for validating a single answer object in the request body.
 const answerSchema = z.object({
@@ -113,4 +153,261 @@ export async function POST(request: NextRequest) {
         console.error('POST /api/season-answers: Unexpected Error:', error);
         return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
     }
+}
+
+/**
+ * Handles GET requests to /api/season-answers for fetching transparency data.
+ * 
+ * Returns both user predictions and current correct answers for the transparency page.
+ * 
+ * @param {NextRequest} request - The incoming Next.js request object.
+ * @returns {Promise<NextResponse>} A promise that resolves to transparency data or error response.
+ */
+export async function GET(_request: NextRequest) {
+    try {
+        // Use service role client for all database queries (bypasses RLS)
+        const serviceRoleClient = getSupabaseServiceRoleClient();
+        
+        // 1. Get current season
+        const { data: currentSeason, error: seasonError } = await serviceRoleClient
+            .from('seasons')
+            .select('id')
+            .eq('is_current', true)
+            .single();
+
+        if (seasonError || !currentSeason) {
+            console.error('GET /api/season-answers: Failed to fetch current season:', seasonError);
+            return NextResponse.json({ error: 'Failed to determine current season' }, { status: 500 });
+        }
+
+        const seasonId = currentSeason.id;
+
+        // 2. Fetch ALL user profiles first (to show all users, even those who haven't answered)
+        // Use service role client to bypass RLS and read all profiles
+        const { data: profiles, error: profilesError } = await serviceRoleClient
+            .from('profiles')
+            .select('id, full_name');
+
+        if (profilesError) {
+            console.error('GET /api/season-answers: Failed to fetch user profiles:', profilesError);
+            return NextResponse.json({ error: 'Failed to fetch user profiles' }, { status: 500 });
+        }
+
+        console.log(`GET /api/season-answers: Found ${profiles?.length || 0} total profiles in database`);
+
+        // 2b. Fetch user predictions without joins first to see what IDs we have
+        // Use service role client to bypass RLS and read all user answers
+        const { data: userAnswers, error: userAnswersError } = await serviceRoleClient
+            .from('user_season_answers')
+            .select(`
+                user_id,
+                question_type,
+                answered_team_id,
+                answered_player_id
+            `)
+            .eq('season_id', seasonId);
+
+        if (userAnswersError) {
+            console.error('GET /api/season-answers: Failed to fetch user answers:', userAnswersError);
+            return NextResponse.json({ error: 'Failed to fetch user predictions' }, { status: 500 });
+        }
+
+        console.log(`GET /api/season-answers: Found ${userAnswers?.length || 0} user answers for season ${seasonId}`);
+
+        // Create profile lookup map (handle null full_name values)
+        const profileMap = new Map(profiles?.map(p => [p.id, p.full_name || `User ${p.id}`]) || []);
+
+        // 3. Get current correct answers using our multiple answers logic
+        // Use the singleton instance
+        
+        // Get current league data (including current standings)
+        // Note: Using hardcoded league/season for MVP - will be dynamic in future
+        const [topScorers, bestGoalDifferenceTeams, currentLeagueTable, lastPlaceTeam] = await Promise.all([
+            LeagueDataService.getTopScorers(165, 2025), // Premier League 2025
+            LeagueDataService.getBestGoalDifferenceTeams(165, 2025), // Premier League 2025
+            LeagueDataService.getCurrentLeagueTable(165, 2025), // Current standings
+            LeagueDataService.getLastPlaceTeam(165, 2025) // Current last place team
+        ]);
+
+        // Get current league winner (first place team) and team names for display
+        const currentLeagueWinner = currentLeagueTable?.standings?.[0];
+        const currentLeagueWinnerTeamId = currentLeagueWinner?.team_id;
+        
+        // Get names for display - use api_player_id and api_team_id to match external API IDs
+        // Use service role client for consistency
+        const [topScorerNames, bestGoalDifferenceNames, leagueWinnerName, lastPlaceName] = await Promise.all([
+            Promise.all(topScorers.map(async (playerId) => {
+                const { data } = await serviceRoleClient
+                    .from('players')
+                    .select('name')
+                    .eq('api_player_id', playerId)
+                    .single();
+                return data?.name || `Player ${playerId}`;
+            })),
+            Promise.all(bestGoalDifferenceTeams.map(async (teamId) => {
+                const { data } = await serviceRoleClient
+                    .from('teams')
+                    .select('name')
+                    .eq('api_team_id', teamId)
+                    .single();
+                return data?.name || `Team ${teamId}`;
+            })),
+            // Get current league winner name
+            currentLeagueWinnerTeamId ? (async () => {
+                const { data } = await serviceRoleClient
+                    .from('teams')
+                    .select('name')
+                    .eq('api_team_id', currentLeagueWinnerTeamId)
+                    .single();
+                return data?.name || `Team ${currentLeagueWinnerTeamId}`;
+            })() : Promise.resolve('TBD'),
+            // Get current last place team name
+            lastPlaceTeam?.team_id ? (async () => {
+                const { data } = await serviceRoleClient
+                    .from('teams')
+                    .select('name')
+                    .eq('api_team_id', lastPlaceTeam.team_id)
+                    .single();
+                return data?.name || `Team ${lastPlaceTeam.team_id}`;
+            })() : Promise.resolve('TBD')
+        ]);
+
+        // 4. Manually fetch team and player names for user answers
+        const userPredictionsWithNames = await transformUserPredictionsWithNames(userAnswers, profileMap, profiles, serviceRoleClient);
+
+        // 5. Create current answers data
+        const currentAnswers = [
+            {
+                question_type: 'league_winner',
+                question_label: 'League Winner',
+                current_answer: leagueWinnerName || 'TBD',
+                points_value: 3
+            },
+            {
+                question_type: 'best_goal_difference',
+                question_label: 'Best Goal Difference',
+                current_answer: bestGoalDifferenceNames.length > 1 
+                    ? `${bestGoalDifferenceNames.join(', ')} (${bestGoalDifferenceNames.length} tied)`
+                    : bestGoalDifferenceNames[0] || 'TBD',
+                points_value: 3
+            },
+            {
+                question_type: 'top_scorer',
+                question_label: 'Top Scorer',
+                current_answer: topScorerNames.length > 1 
+                    ? `${topScorerNames.join(', ')} (${topScorerNames.length} tied)`
+                    : topScorerNames[0] || 'TBD',
+                points_value: 3
+            },
+            {
+                question_type: 'last_place',
+                question_label: 'Last Place',
+                current_answer: lastPlaceName || 'TBD',
+                points_value: 3
+            }
+        ];
+
+        console.log(`GET /api/season-answers: Success - ${userPredictionsWithNames.length} user predictions, ${currentAnswers.length} current answers`);
+        
+        return NextResponse.json({
+            userPredictions: userPredictionsWithNames,
+            currentAnswers,
+            season_id: seasonId
+        }, { status: 200 });
+
+    } catch (error) {
+        console.error('GET /api/season-answers: Unexpected Error:', error);
+        return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
+    }
+}
+
+/**
+ * Transform raw user answers data into the format expected by the UI
+ * Shows ALL users from profiles, with answers where they exist and null where they don't
+ * Manually fetches team and player names for user answers
+ */
+async function transformUserPredictionsWithNames(
+    userAnswers: RawUserAnswer[], 
+    profileMap: Map<string, string>,
+    allProfiles: { id: string; full_name: string | null }[],
+    serviceRoleClient: ServiceRoleClient
+): Promise<UserPrediction[]> {
+    const userMap = new Map<string, UserPrediction>();
+
+    // First, create entries for ALL users (even those who haven't answered)
+    allProfiles.forEach(profile => {
+        userMap.set(profile.id, {
+            user_id: profile.id,
+            username: profile.full_name || `User ${profile.id}`,
+            league_winner: null,
+            best_goal_difference: null,
+            top_scorer: null,
+            last_place: null
+        });
+    });
+
+    // Then, populate answers for users who have them
+    // First get all unique team and player IDs to fetch names efficiently
+    const teamIds: number[] = [];
+    const playerIds: number[] = [];
+    
+    userAnswers.forEach(answer => {
+        if (answer.answered_team_id) teamIds.push(answer.answered_team_id);
+        if (answer.answered_player_id) playerIds.push(answer.answered_player_id);
+    });
+
+    // Fetch team and player names in batches
+    const [teamsData, playersData] = await Promise.all([
+        teamIds.length > 0 ? serviceRoleClient
+            .from('teams')
+            .select('id, name')
+            .in('id', [...new Set(teamIds)]) : Promise.resolve({ data: [] }),
+        playerIds.length > 0 ? serviceRoleClient
+            .from('players')
+            .select('id, name')
+            .in('id', [...new Set(playerIds)]) : Promise.resolve({ data: [] })
+    ]);
+
+    // Create lookup maps with proper typing (handle null names)
+    const teamNameMap = new Map(teamsData.data?.map((team: TeamData) => [team.id, team.name || `Team ${team.id}`]) || []);
+    const playerNameMap = new Map(playersData.data?.map((player: PlayerData) => [player.id, player.name || `Player ${player.id}`]) || []);
+
+    // Populate user answers with resolved names
+    userAnswers.forEach(answer => {
+        const userId = answer.user_id;
+        const user = userMap.get(userId);
+        
+        if (user) {
+            let answerName = 'Unknown';
+            
+            if (answer.answered_team_id) {
+                answerName = teamNameMap.get(answer.answered_team_id) || `Team ${answer.answered_team_id}`;
+            } else if (answer.answered_player_id) {
+                answerName = playerNameMap.get(answer.answered_player_id) || `Player ${answer.answered_player_id}`;
+            }
+            
+            // Map question types to user object properties
+            switch (answer.question_type) {
+                case 'league_winner':
+                    user.league_winner = answerName;
+                    break;
+                case 'best_goal_difference':
+                    user.best_goal_difference = answerName;
+                    break;
+                case 'top_scorer':
+                    user.top_scorer = answerName;
+                    break;
+                case 'last_place':
+                    user.last_place = answerName;
+                    break;
+            }
+        }
+    });
+
+    // Sort by username for consistent ordering
+    return Array.from(userMap.values()).sort((a, b) => {
+        const nameA = a.username || '';
+        const nameB = b.username || '';
+        return nameA.localeCompare(nameB);
+    });
 } 

--- a/src/components/answers/CurrentAnswersTable.tsx
+++ b/src/components/answers/CurrentAnswersTable.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface CurrentAnswer {
+  question_type: string;
+  question_label: string;
+  current_answer: string;
+  points_value: number;
+}
+
+interface CurrentAnswersTableProps {
+  data: CurrentAnswer[];
+}
+
+const CurrentAnswersTable: React.FC<CurrentAnswersTableProps> = ({ data }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="p-4 my-4 text-sm text-gray-700 rounded-lg bg-gray-100 dark:bg-gray-800 dark:text-gray-300" role="alert">
+        No current answers available yet.
+      </div>
+    );
+  }
+
+  // Create a map for easy lookup of answers by question type
+  const answerMap = new Map(data.map(answer => [answer.question_type, answer.current_answer]));
+
+  return (
+    <TooltipProvider>
+      <div className="border shadow-md sm:rounded-lg my-6 overflow-hidden">
+        <Table>
+          <TableCaption className="py-3 px-4 text-xs text-gray-500 dark:text-gray-400 text-left">
+            Current correct answers for season-long questions (updated dynamically)
+          </TableCaption>
+          <TableHeader>
+            <TableRow className="bg-primary hover:bg-primary/90">
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold">
+                League Winner{' '}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="cursor-help">(?)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Current team in 1st place</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold">
+                Best Goal Difference{' '}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="cursor-help">(?)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Team with highest goal difference</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold">
+                Top Scorer{' '}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="cursor-help">(?)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Player with most goals scored</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold">
+                Last Place{' '}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="cursor-help">(?)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Current team in last place</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow className="bg-green-50 dark:bg-green-900/20 hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors duration-150 ease-in-out">
+              <TableCell className="px-3 py-4 font-semibold text-primary dark:text-teal-400">
+                {answerMap.get('league_winner') || 'TBD'}
+              </TableCell>
+              <TableCell className="px-3 py-4 font-semibold text-primary dark:text-teal-400">
+                {answerMap.get('best_goal_difference') || 'TBD'}
+              </TableCell>
+              <TableCell className="px-3 py-4 font-semibold text-primary dark:text-teal-400">
+                {answerMap.get('top_scorer') || 'TBD'}
+              </TableCell>
+              <TableCell className="px-3 py-4 font-semibold text-primary dark:text-teal-400">
+                {answerMap.get('last_place') || 'TBD'}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+        
+        {/* Additional transparency note */}
+        <div className="px-4 py-3 bg-blue-50 dark:bg-blue-900/20 border-t">
+          <p className="text-xs text-blue-700 dark:text-blue-300">
+            <strong>Note:</strong> These answers update automatically as the season progresses. 
+            Users earn points when their predictions match the current leaders.
+          </p>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+};
+
+export default CurrentAnswersTable; 

--- a/src/components/answers/UserPredictionsTable.tsx
+++ b/src/components/answers/UserPredictionsTable.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface UserPrediction {
+  user_id: string;
+  username?: string;
+  league_winner?: string;
+  best_goal_difference?: string;
+  top_scorer?: string;
+  last_place?: string;
+}
+
+interface UserPredictionsTableProps {
+  data: UserPrediction[];
+}
+
+const UserPredictionsTable: React.FC<UserPredictionsTableProps> = ({ data }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="p-4 my-4 text-sm text-gray-700 rounded-lg bg-gray-100 dark:bg-gray-800 dark:text-gray-300" role="alert">
+        No user predictions available yet.
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="border shadow-md sm:rounded-lg my-6 overflow-hidden">
+        <Table>
+          <TableCaption className="py-3 px-4 text-xs text-gray-500 dark:text-gray-400 text-left">
+            All user predictions for season-long questions
+          </TableCaption>
+          <TableHeader>
+            <TableRow className="bg-primary hover:bg-primary/90">
+              <TableHead className="px-6 py-3 text-xs text-primary-foreground font-semibold">Name</TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold text-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>League Winner (3p)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Which team will win the league championship</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold text-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>Best Goal Difference (3p)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Which team will have the best goal difference</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold text-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>Top Scorer (3p)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Which player will score the most goals</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className="px-3 py-3 text-xs text-primary-foreground font-semibold text-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>Last Place (3p)</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Which team will finish in last place</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((prediction, _index) => (
+              <TableRow 
+                key={prediction.user_id} 
+                className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors duration-150 ease-in-out"
+              >
+                <TableCell className="px-6 py-4 font-medium text-gray-900 dark:text-white truncate max-w-xs">
+                  {prediction.username || prediction.user_id}
+                </TableCell>
+                <TableCell className="px-3 py-4 text-center text-gray-700 dark:text-gray-300">
+                  {prediction.league_winner || '-'}
+                </TableCell>
+                <TableCell className="px-3 py-4 text-center text-gray-700 dark:text-gray-300">
+                  {prediction.best_goal_difference || '-'}
+                </TableCell>
+                <TableCell className="px-3 py-4 text-center text-gray-700 dark:text-gray-300">
+                  {prediction.top_scorer || '-'}
+                </TableCell>
+                <TableCell className="px-3 py-4 text-center text-gray-700 dark:text-gray-300">
+                  {prediction.last_place || '-'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </TooltipProvider>
+  );
+};
+
+export default UserPredictionsTable; 

--- a/src/components/answers/index.ts
+++ b/src/components/answers/index.ts
@@ -1,0 +1,2 @@
+export { default as UserPredictionsTable } from './UserPredictionsTable';
+export { default as CurrentAnswersTable } from './CurrentAnswersTable'; 

--- a/src/components/layout/DesktopHeader.tsx
+++ b/src/components/layout/DesktopHeader.tsx
@@ -18,6 +18,11 @@ export function DesktopHeader() {
               Tabell
             </span>
           </Link>
+          <Link href="/answers" passHref>
+            <span className="text-sm font-medium text-muted-foreground hover:text-primary cursor-pointer">
+              Svar
+            </span>
+          </Link>
         </div>
       </nav>
     </header>

--- a/src/components/layout/MobileBottomNav.tsx
+++ b/src/components/layout/MobileBottomNav.tsx
@@ -13,6 +13,11 @@ export function MobileBottomNav() {
           Tabell
         </span>
       </Link>
+      <Link href="/answers" passHref>
+        <span className="text-sm font-medium text-muted-foreground hover:text-primary cursor-pointer p-2">
+          Svar
+        </span>
+      </Link>
     </nav>
   );
 } 

--- a/src/components/layout/SectionContainer.tsx
+++ b/src/components/layout/SectionContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, ReactNode } from 'react';
 import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,4 +4,5 @@ export * from './command';
 export * from './dialog';
 export * from './popover';
 export * from './badge';
-export * from './combobox'; 
+export * from './combobox';
+export * from './tabs'; 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent } 

--- a/src/lib/leagueDataService.ts
+++ b/src/lib/leagueDataService.ts
@@ -753,4 +753,8 @@ export class LeagueDataServiceImpl implements ILeagueDataService {
       return [];
     }
   }
-} 
+}
+
+// Export a singleton instance as the default export
+const LeagueDataService = new LeagueDataServiceImpl();
+export default LeagueDataService; 


### PR DESCRIPTION
…rrent correct answers

- Add new /answers page with tabbed interface for transparency view
- Create UserPredictionsTable component showing all users' season predictions
- Create CurrentAnswersTable component displaying live correct answers
- Extend /api/season-answers with GET method for transparency data
- Integrate multiple correct answers logic with real-time league data
- Add Answers navigation to both desktop header and mobile bottom nav
- Implement shadcn/ui Tabs component for clean interface
- Handle RLS bypass using service role client for full data access
- Add proper TypeScript interfaces and error handling
- Resolve team/player name lookups using external API IDs
- Show fallback values for users who haven't answered questions
- Clean layout improvements removing unnecessary page wrappers

Technical details:
- Manual name resolution approach for reliable team/player display
- Batch queries for efficient database access
- Service role client bypasses RLS to show all users
- Live integration with LeagueDataService for current standings
- Comprehensive error handling with detailed logging

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 