### PR TITLE
feat: implement bonus round system with 2x points multiplier

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -130,6 +130,7 @@ export type Database = {
           created_at: string
           earliest_fixture_kickoff: string | null
           id: number
+          is_bonus_round: boolean | null
           latest_fixture_kickoff: string | null
           name: string
           reminder_sent_at: string | null
@@ -143,6 +144,7 @@ export type Database = {
           created_at?: string
           earliest_fixture_kickoff?: string | null
           id?: number
+          is_bonus_round?: boolean | null
           latest_fixture_kickoff?: string | null
           name: string
           reminder_sent_at?: string | null
@@ -156,6 +158,7 @@ export type Database = {
           created_at?: string
           earliest_fixture_kickoff?: string | null
           id?: number
+          is_bonus_round?: boolean | null
           latest_fixture_kickoff?: string | null
           name?: string
           reminder_sent_at?: string | null
@@ -523,6 +526,7 @@ export type Database = {
       seasons: {
         Row: {
           api_season_year: number
+          bonus_mode_active: boolean | null
           competition_id: number
           completed_at: string | null
           coverage_json: Json | null
@@ -539,6 +543,7 @@ export type Database = {
         }
         Insert: {
           api_season_year: number
+          bonus_mode_active?: boolean | null
           competition_id: number
           completed_at?: string | null
           coverage_json?: Json | null
@@ -555,6 +560,7 @@ export type Database = {
         }
         Update: {
           api_season_year?: number
+          bonus_mode_active?: boolean | null
           competition_id?: number
           completed_at?: string | null
           coverage_json?: Json | null
@@ -983,3 +989,4 @@ export const Constants = {
     },
   },
 } as const
+


### PR DESCRIPTION
Add comprehensive bonus round functionality allowing admins to activate 2x point multipliers for correct game predictions:

- Add database columns: is_bonus_round (per round) and bonus_mode_active (season-wide)
- Implement admin UI with toggles in Season Settings section
- Update scoring logic to apply 2x multiplier when bonus mode is active
- Support both individual round bonus and global season bonus mode
- Add comprehensive test coverage for bonus functionality
- Update TypeScript types for new database columns

When bonus mode is active, users receive 2 points instead of 1 for correct game predictions. Dynamic questionnaire points remain unchanged at 3 points. Admins can activate bonus mode globally or toggle individual rounds.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 