### PR TITLE
fix: Make populate API async again to avoid Vercel timeout

### DIFF
--- a/src/app/api/populate-fixtures/route.ts
+++ b/src/app/api/populate-fixtures/route.ts
@@ -15,15 +15,17 @@ export async function GET() {
   try {
     console.log(`🚀 Starting population for league ${leagueId}, season ${seasonYear}...`);
     
-    // Await the populate function so we can see the results immediately
-    await populateFixturesForSeason(leagueId, seasonYear);
-
-    console.log(`✅ Population completed for league ${leagueId}, season ${seasonYear}.`);
+    // Run asynchronously to avoid Vercel timeout, but logs will show progress
+    populateFixturesForSeason(leagueId, seasonYear).then(() => {
+      console.log(`✅ Population completed for league ${leagueId}, season ${seasonYear}.`);
+    }).catch((error) => {
+      console.error(`❌ Population failed for league ${leagueId}, season ${seasonYear}:`, error);
+    });
 
     return NextResponse.json({
-      message: `Population completed successfully for league ${leagueId}, season ${seasonYear}.`,
+      message: `Population started for league ${leagueId}, season ${seasonYear}. Check server logs for progress.`,
       success: true
-    }, { status: 200 }); // 200 OK indicates the process completed
+    }, { status: 202 }); // 202 Accepted indicates the process has started
 
   } catch (error: unknown) {
     console.error('Error triggering population route:', error);


### PR DESCRIPTION
- Changed back to async execution to prevent function timeout
- Added proper error handling with promise chain
- Maintained enhanced logging while avoiding 16s timeout limit

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 