### PR TITLE
fix: Prevent white background flash in mobile webviews

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,6 +65,14 @@
 body {
   background: hsl(var(--background));
   color: hsl(var(--foreground));
+  /* Fallback for webviews that don't load CSS properly */
+  background-color: #1a1a1a !important;
+  color: #ffffff !important;
+}
+
+/* Ensure root html element also has dark background */
+html {
+  background-color: #1a1a1a !important;
 }
 
 /* Custom responsive utilities */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,8 +72,24 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
+      <head>
+        <style dangerouslySetInnerHTML={{
+          __html: `
+            /* Prevent white flash before theme loads */
+            html, body { 
+              background-color: #1a1a1a !important; 
+              color: #ffffff !important;
+            }
+            /* Override any potential white backgrounds */
+            * { 
+              background-color: inherit; 
+            }
+          `
+        }} />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        style={{ backgroundColor: '#1a1a1a', color: '#ffffff' }}
       >
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
- Add inline critical CSS to set dark background before JavaScript loads
- Include inline body styles as additional fallback
- Add CSS \!important overrides in globals.css for webview compatibility
- Fix white background issue in Messenger, WhatsApp, and other mobile webviews
- Ensure consistent dark theme experience across all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 