### PR TITLE
fix: Enable proper light/dark theme switching with webview compatibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,13 +67,22 @@ body {
   color: hsl(var(--foreground));
 }
 
-/* Only override background color in dark mode for webview compatibility */
+/* Override background colors for webview compatibility */
 html.dark {
   background-color: #1a1a1a;
 }
 
 html.dark body {
   background-color: #1a1a1a;
+}
+
+/* Ensure light mode has proper white background */
+html:not(.dark) {
+  background-color: #ffffff;
+}
+
+html:not(.dark) body {
+  background-color: #ffffff;
 }
 
 /* Custom responsive utilities */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,12 +79,15 @@ export default function RootLayout({
             html.dark, html.dark body { 
               background-color: #1a1a1a !important; 
             }
+            /* Ensure light mode works properly */
+            html:not(.dark), html:not(.dark) body {
+              background-color: #ffffff !important;
+            }
           `
         }} />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        style={{ backgroundColor: '#1a1a1a' }}
       >
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
- Add explicit light mode CSS selectors using :not(.dark)
- Include light mode background override in critical inline CSS
- Remove fixed dark background inline style from body
- Ensure theme switching works instantly in both directions
- Maintain Messenger webview compatibility for both themes
- Fix issue where light mode still showed dark background

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 