### PR TITLE
feat: Add centralized rate limiting for all email endpoints

### DIFF
--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -1,0 +1,91 @@
+/**
+ * Rate limiter for Resend API
+ * Ensures we don't exceed 2 requests per second
+ */
+export class RateLimiter {
+  private queue: Array<() => void> = [];
+  private processing = false;
+  private lastRequestTime = 0;
+  
+  // Resend allows 2 requests per second
+  // We'll be conservative and do 1.8 per second to avoid edge cases
+  private readonly minDelayMs = 550; // ~1.8 requests per second
+  
+  /**
+   * Execute a function with rate limiting
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push(async () => {
+        try {
+          const result = await fn();
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        }
+      });
+      
+      if (!this.processing) {
+        this.processQueue();
+      }
+    });
+  }
+  
+  private async processQueue() {
+    if (this.processing || this.queue.length === 0) {
+      return;
+    }
+    
+    this.processing = true;
+    
+    while (this.queue.length > 0) {
+      const now = Date.now();
+      const timeSinceLastRequest = now - this.lastRequestTime;
+      
+      // Wait if we need to respect rate limit
+      if (timeSinceLastRequest < this.minDelayMs) {
+        await new Promise(resolve => 
+          setTimeout(resolve, this.minDelayMs - timeSinceLastRequest)
+        );
+      }
+      
+      const task = this.queue.shift();
+      if (task) {
+        this.lastRequestTime = Date.now();
+        await task();
+      }
+    }
+    
+    this.processing = false;
+  }
+  
+  /**
+   * Process multiple items with rate limiting
+   * Returns results in the same order as input
+   */
+  async processWithRateLimit<T, R>(
+    items: T[],
+    processor: (item: T) => Promise<R>,
+    options?: {
+      onProgress?: (completed: number, total: number) => void;
+    }
+  ): Promise<R[]> {
+    const results: R[] = [];
+    let completed = 0;
+    
+    for (const item of items) {
+      const result = await this.execute(() => processor(item));
+      results.push(result);
+      completed++;
+      
+      if (options?.onProgress) {
+        options.onProgress(completed, items.length);
+      }
+    }
+    
+    return results;
+  }
+}
+
+// Create a singleton instance for email sending
+export const emailRateLimiter = new RateLimiter();


### PR DESCRIPTION
- Create RateLimiter utility class to enforce Resend's 2 req/sec limit
- Update sendEmail() to automatically apply rate limiting
- Add sendBulkEmails() function with progress tracking
- Prevent 429 rate limit errors across all email types
- Conservative 1.8 req/sec to avoid edge cases
- Test mode bypasses rate limiting

All existing email endpoints now automatically protected:
- Reminder emails
- Transparency emails
- Summary emails
- Admin notifications

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 