### PR TITLE
fix: Improve text visibility in combobox for dark mode

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -516,9 +516,9 @@ export function Combobox({
                 className={cn(
                   "h-10 flex-1",
                   "border-0 border-none",
-                  "bg-transparent text-gray-800",
+                  "bg-transparent text-gray-800 dark:text-gray-100",
                   "focus:ring-0 focus:outline-none",
-                  "placeholder:text-gray-400"
+                  "placeholder:text-gray-400 dark:placeholder:text-gray-500"
                 )}
                 ref={inputRef}
                 aria-autocomplete="list"


### PR DESCRIPTION
- Add dark:text-gray-100 to CommandInput for white text in dark mode
- Add dark:placeholder:text-gray-500 for better placeholder visibility
- Fixes hard to read text when typing in questionnaire dropdowns

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 