### PR TITLE
fix: Implement admin summary email recovery for missed rounds

### DIFF
--- a/src/app/api/cron/email-scheduler/route.ts
+++ b/src/app/api/cron/email-scheduler/route.ts
@@ -56,6 +56,7 @@ export async function GET(request: Request) {
     const summaryEmails = results.filter(r => r.emailType === 'summary').length;
     const reminderEmails = results.filter(r => r.emailType === 'reminder').length;
     const transparencyEmails = results.filter(r => r.emailType === 'transparency').length;
+    const adminSummaryEmails = results.filter(r => r.emailType === 'admin-summary').length;
 
     const summary = {
       success: true,
@@ -67,6 +68,7 @@ export async function GET(request: Request) {
       summary_emails: summaryEmails,
       reminder_emails: reminderEmails,
       transparency_emails: transparencyEmails,
+      admin_summary_emails: adminSummaryEmails,
       timestamp: new Date().toISOString()
     };
 


### PR DESCRIPTION
- Add checkForMissedAdminSummaries() method to catch scored rounds without admin emails
- Integrate into main email scheduling workflow to run on every cron execution
- Update cron response tracking to include admin-summary email counts
- Fix Jest test interference by properly managing global Supabase mocks
- Add comprehensive Mock Pollution Prevention guide to testing documentation

This addresses the Round 42 issue where admin summary was never sent because the original logic only checked 'open' rounds, not 'scored' ones. The new system will catch and send admin summaries for any rounds scored within 24 hours.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 