### PR TITLE
fix: Prevent duplicate email deliveries by checking existing records

### DIFF
--- a/src/lib/__tests__/emailScheduler.test.ts
+++ b/src/lib/__tests__/emailScheduler.test.ts
@@ -279,6 +279,20 @@ describe('EmailSchedulerService', () => {
             })
           };
         }
+        if (table === 'email_deliveries') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  limit: jest.fn().mockResolvedValue({
+                    data: [], // No existing delivery records
+                    error: null
+                  })
+                })
+              })
+            })
+          };
+        }
         return {};
       });
 
@@ -392,6 +406,20 @@ describe('EmailSchedulerService', () => {
               not: jest.fn().mockResolvedValue({
                 data: [{ user_id: 'user1' }, { user_id: 'user2' }],
                 error: null
+              })
+            })
+          };
+        }
+        if (table === 'email_deliveries') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  limit: jest.fn().mockResolvedValue({
+                    data: [], // No existing delivery records
+                    error: null
+                  })
+                })
               })
             })
           };


### PR DESCRIPTION
- Add check in setupReminderDeliveryTracking to prevent recreating delivery records
- Fix issue where cron job would reset delivery status every hour within 24h window
- Update tests to mock the new email_deliveries table check
- Resolves issue where users received multiple reminder emails

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 