### PR TITLE
fix: Simplify password reset redirect to bypass callback

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -52,7 +52,7 @@ export default function AuthModal({ children }: AuthModalProps) {
     setIsLoading(true)
 
     try {
-      const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent('/auth/reset-password')}`
+      const redirectTo = `${window.location.origin}/auth/reset-password`
       
       if (shouldUseAuthWorkaround()) {
         // Development workaround: Use direct API call


### PR DESCRIPTION
The password reset flow was redirecting through /auth/callback which added unnecessary complexity and was causing users to be redirected to the landing page instead of the password reset form. This change makes the redirect go directly to /auth/reset-password, bypassing the callback route entirely.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 