### PR TITLE
fix: Add password reset route to public routes in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const publicRoutes = [
   '/',
   '/auth/signin',
   '/auth/callback',
+  '/auth/reset-password',
   '/auth/access-denied',
   '/auth/auth-code-error',
   '/api/health',


### PR DESCRIPTION
The password reset page was being redirected to the landing page because the middleware was treating /auth/reset-password as a protected route and redirecting unauthenticated users to signin. This route needs to be public so users can access it from their password reset email links.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 