### PR TITLE
fix: Use consistent primary domain for password reset redirects

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -52,7 +52,13 @@ export default function AuthModal({ children }: AuthModalProps) {
     setIsLoading(true)
 
     try {
-      const redirectTo = `${window.location.origin}/auth/reset-password`
+      // Always use the primary domain for password reset to ensure Supabase accepts it
+      // This prevents issues when users access the site from different domains (e.g., apl.zone)
+      const primaryDomain = process.env.NEXT_PUBLIC_APP_URL || 'https://league-coupon.vercel.app'
+      const redirectTo = `${primaryDomain}/auth/reset-password`
+      console.log('Password reset requested with redirectTo:', redirectTo)
+      console.log('Current origin:', window.location.origin)
+      console.log('Using primary domain:', primaryDomain)
       
       if (shouldUseAuthWorkaround()) {
         // Development workaround: Use direct API call


### PR DESCRIPTION
Previously, password reset emails were failing when users requested them from apl.zone because window.location.origin would use apl.zone as the redirect domain, which wasn't configured in Supabase's allowed redirect URLs. This caused Supabase to fall back to the default Site URL (root path).

Now always use the primary domain (league-coupon.vercel.app) for password reset redirects to ensure consistency and proper Supabase configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 